### PR TITLE
Update node version to fix build on master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 dist: trusty
 language: node_js
-node_js: 8.1
+node_js: 8.11
 
 cache:
   directories:


### PR DESCRIPTION
The build error on master is caused by [fs.copyFileSync](https://nodejs.org/api/fs.html#fs_fs_copyfilesync_src_dest_flags) used by `vaadin-usage-statistics`. That feature was added in node.js 8.5.0

The node.js version here is 8.1 which is too old (and is a pre-LTS so we don't have to support it).
Let's update to 8.11 which is used by all the components, in order to get green build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin/48)
<!-- Reviewable:end -->
