### PR TITLE
chore: remove confirm-dialog dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   "dependencies": {
     "@vaadin/board": "23.2.0-alpha5",
     "@vaadin/charts": "23.2.0-alpha5",
-    "@vaadin/confirm-dialog": "23.2.0-alpha5",
     "@vaadin/cookie-consent": "23.2.0-alpha5",
     "@vaadin/crud": "23.2.0-alpha5",
     "@vaadin/grid-pro": "23.2.0-alpha5",
@@ -16,7 +15,6 @@
     "@vaadin/rich-text-editor": "23.2.0-alpha5",
     "@vaadin/vaadin-board": "23.2.0-alpha5",
     "@vaadin/vaadin-charts": "23.2.0-alpha5",
-    "@vaadin/vaadin-confirm-dialog": "23.2.0-alpha5",
     "@vaadin/vaadin-cookie-consent": "23.2.0-alpha5",
     "@vaadin/vaadin-core": "23.2.0-alpha3",
     "@vaadin/vaadin-crud": "23.2.0-alpha5",

--- a/vaadin.js
+++ b/vaadin.js
@@ -1,7 +1,6 @@
 import '@vaadin/vaadin-core';
 import '@vaadin/board';
 import '@vaadin/charts';
-import '@vaadin/confirm-dialog';
 import '@vaadin/cookie-consent';
 import '@vaadin/crud';
 import '@vaadin/grid-pro';


### PR DESCRIPTION
## Description

The `vaadin-confirm-dialog` is moved from Pro to `vaadin-core`, so let's remove it from here.
